### PR TITLE
Apply TS strict mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,7 @@ typings/
 # dotenv environment variables file
 .env
 
+# compiled
+dist/
 
 \.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
-# compiled
-dist/
 
 \.idea/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 
+Copyright (c) 2020
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/__tests__/openList.test.ts
+++ b/__tests__/openList.test.ts
@@ -32,7 +32,7 @@ describe('test openList', () => {
     })
 
     it("errors when popping from empty list", () => {
-        expect(() => list.pop()).toThrowError("Popping from an empty list.")
+        expect(() => list.pop()).toThrowError(ReferenceError)
     })
 
 })

--- a/__tests__/pathFinding.test.ts
+++ b/__tests__/pathFinding.test.ts
@@ -1,64 +1,82 @@
-import {Grid} from "../src";
+import { Grid } from '../src';
+import { PointInterface } from '../src/objects/point/point.interface';
 
 describe('test path finding', () => {
-
     const grid = new Grid([
         [50, 55, 60, 65, 70],
-        [45, 0,  0,  0,  75],
-        [40, 0,  0,  0,  1 ],
-        [35, 0,  0,  0,  5 ],
+        [45, 0, 0, 0, 75],
+        [40, 0, 0, 0, 1],
+        [35, 0, 0, 0, 5],
         [30, 25, 20, 15, 10],
     ]);
 
-    it('validates pf {test 1}', () => {
-        const path = grid.findPath(
-            { x: 4, y: 2 },
-            { x: 4, y: 1 }
-        )
-        expect(path).toEqual([
-            {x: 4, y: 2},
-            {x: 4, y: 4},
-            {x: 0, y: 4},
-            {x: 0, y: 0},
-            {x: 4, y: 0},
-            {x: 4, y: 1}
-        ]);
+    const testCases = [
+        {
+            startPoint: { x: 4, y: 2 },
+            endPoint: { x: 4, y: 1 },
+            maxJump: undefined,
+            path: [
+                { x: 4, y: 2 },
+                { x: 4, y: 4 },
+                { x: 0, y: 4 },
+                { x: 0, y: 0 },
+                { x: 4, y: 0 },
+                { x: 4, y: 1 },
+            ],
+        },
+        {
+            startPoint: { x: 4, y: 2 },
+            endPoint: { x: 4, y: 1 },
+            maxJumpCost: 10,
+            path: [
+                { x: 4, y: 2 },
+                { x: 4, y: 4 },
+                { x: 0, y: 4 },
+                { x: 0, y: 0 },
+                { x: 4, y: 0 },
+                { x: 4, y: 1 },
+            ],
+        },
+        {
+            startPoint: { x: 4, y: 2 },
+            endPoint: { x: 4, y: 1 },
+            maxJumpCost: 100,
+            path: [
+                { x: 4, y: 2 },
+                { x: 4, y: 1 },
+            ],
+        },
+        {
+            startPoint: { x: 4, y: 2 },
+            endPoint: { x: 4, y: 1 },
+            maxJumpCost: 1,
+            path: [],
+        },
+    ] as {
+        startPoint: PointInterface;
+        endPoint: PointInterface;
+        maxJumpCost: number;
+        path: PointInterface[];
+    }[];
+
+    testCases.forEach(
+        ({ startPoint, endPoint, maxJumpCost, path: expectedPath }) => {
+            it(`validates pathfinding for jumpCost  ${maxJumpCost}`, () => {
+                const path = grid.findPath(startPoint, endPoint, maxJumpCost);
+                expect(path).toEqual(expectedPath);
+            });
+        }
+    );
+
+    it('throws an error if start point does no exist', () => {
+        const find = () => grid.findPath({ x: 999, y: 999 }, { x: 4, y: 1 });
+
+        expect(find).toThrowError(ReferenceError);
     });
 
-    it('validates pf {test 2}', () => {
-        const path = grid.findPath(
-            { x: 4, y: 2 },
-            { x: 4, y: 1 },
-            10
-        )
-        expect(path).toEqual([
-            {x: 4, y: 2},
-            {x: 4, y: 4},
-            {x: 0, y: 4},
-            {x: 0, y: 0},
-            {x: 4, y: 0},
-            {x: 4, y: 1}
-        ]);
-    });
+    it('throws an error if end point does no exist', () => {
+        const find = () => grid.findPath({ x: 4, y: 1 }, { x: 999, y: 999 });
 
-    it('validates pf {test 3}', () => {
-        const path = grid.findPath(
-            { x: 4, y: 2 },
-            { x: 4, y: 1 },
-            100
-        )
-        expect(path).toEqual([
-            { x: 4, y: 2 },
-            { x: 4, y: 1 }
-        ]);
+        expect(find).toThrowError(ReferenceError);
     });
-
-    it('validates pf {test 4}', () => {
-        const path = grid.findPath(
-            { x: 4, y: 2 },
-            { x: 4, y: 1 },
-            1
-        )
-        expect(path).toEqual([]);
-    });
-})
+});

--- a/__tests__/pathFinding.test.ts
+++ b/__tests__/pathFinding.test.ts
@@ -2,16 +2,17 @@ import { Grid } from '../src';
 import { PointInterface } from '../src/objects/point/point.interface';
 
 describe('test path finding', () => {
-    const grid = new Grid([
+    const grid_A = new Grid([
         [50, 55, 60, 65, 70],
-        [45, 0, 0, 0, 75],
-        [40, 0, 0, 0, 1],
-        [35, 0, 0, 0, 5],
+        [45, 0,  0,  0,  75],
+        [40, 0,  0,  0,  1 ],
+        [35, 0,  0,  0,  5 ],
         [30, 25, 20, 15, 10],
     ]);
 
     const testCases = [
         {
+            grid: grid_A,
             startPoint: { x: 4, y: 2 },
             endPoint: { x: 4, y: 1 },
             maxJump: undefined,
@@ -25,6 +26,7 @@ describe('test path finding', () => {
             ],
         },
         {
+            grid: grid_A,
             startPoint: { x: 4, y: 2 },
             endPoint: { x: 4, y: 1 },
             maxJumpCost: 10,
@@ -38,6 +40,7 @@ describe('test path finding', () => {
             ],
         },
         {
+            grid: grid_A,
             startPoint: { x: 4, y: 2 },
             endPoint: { x: 4, y: 1 },
             maxJumpCost: 100,
@@ -47,36 +50,59 @@ describe('test path finding', () => {
             ],
         },
         {
+            grid: grid_A,
             startPoint: { x: 4, y: 2 },
             endPoint: { x: 4, y: 1 },
             maxJumpCost: 1,
             path: [],
         },
+        {
+            grid: grid_A,
+            startPoint: { x: 2, y: 0 },
+            endPoint: { x: 4, y: 4 },
+            maxJumpCost: 10,
+            path: [
+                { x: 2, y: 0 },
+                { x: 0, y: 0 },
+                { x: 0, y: 4 },
+                { x: 4, y: 4 },
+            ],
+        },
     ] as {
+        grid: Grid;
         startPoint: PointInterface;
         endPoint: PointInterface;
         maxJumpCost: number;
         path: PointInterface[];
     }[];
 
-    testCases.forEach(
-        ({ startPoint, endPoint, maxJumpCost, path: expectedPath }) => {
-            it(`validates pathfinding for jumpCost  ${maxJumpCost}`, () => {
-                const path = grid.findPath(startPoint, endPoint, maxJumpCost);
-                expect(path).toEqual(expectedPath);
-            });
-        }
-    );
+    testCases.forEach(({
+        startPoint,
+        endPoint,
+        maxJumpCost,
+        path: expectedPath,
+        grid
+    }) => {
+        it(`validates pathfinding for jumpCost  ${maxJumpCost}`, () => {
+            const path = grid.findPath(startPoint, endPoint, maxJumpCost);
+            expect(path).toEqual(expectedPath);
+        });
+    });
 
     it('throws an error if start point does no exist', () => {
-        const find = () => grid.findPath({ x: 999, y: 999 }, { x: 4, y: 1 });
+        const find = () => grid_A.findPath({ x: 999, y: 999 }, { x: 4, y: 1 });
 
         expect(find).toThrowError(ReferenceError);
     });
 
     it('throws an error if end point does no exist', () => {
-        const find = () => grid.findPath({ x: 4, y: 1 }, { x: 999, y: 999 });
+        const find = () => grid_A.findPath({ x: 4, y: 1 }, { x: 999, y: 999 });
 
         expect(find).toThrowError(ReferenceError);
+    });
+
+    it('throws an error if grid is empty', () => {
+        const createEmptyGrid = () => new Grid([]);
+        expect(createEmptyGrid).toThrowError(ReferenceError);
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pathfinding.ts",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "pathfinding.ts",
   "version": "1.0.4",
   "description": "",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
   "repository": "https://github.com/darkaqua/pathfinding.ts",
   "scripts": {
     "start": "./node_modules/.bin/ts-node ./src/index.ts",

--- a/src/finders/jumpPoint.finder.ts
+++ b/src/finders/jumpPoint.finder.ts
@@ -12,16 +12,16 @@ export const findPath = (
     grid: Grid
 ): PointInterface[] => {
 
-    const openList: OpenList<Node> = new OpenList<Node>((nodeA, nodeB) => nodeA.f - nodeB.f);
-    const startNode: Node = grid.getNode(startPoint);
-    const endNode: Node = grid.getNode(endPoint);
+    const openList: OpenList<Node> = new OpenList<Node>(
+        (nodeA, nodeB) => nodeA.totalCost - nodeB.totalCost);
+    const startNode: Node | null = grid.getNode(startPoint);
+    const endNode: Node | null = grid.getNode(endPoint);
 
-    if (startNode === null) {
+    if (startNode === null)
         throw ReferenceError('startNode does not exist in the grid');
-    }
-    if (endNode === null) {
+
+    if (endNode === null)
         throw ReferenceError('endNode does not exist in the grid');
-    }
 
     startNode.opened = true;
     openList.push(startNode);
@@ -120,12 +120,9 @@ export const findPath = (
     ) => {
         return directions.reduce((acc: Node[], direction: [number, number]) => {
             const node = grid.getNode(reference.copy(...direction));
-            if (node && node.cost > 0) {
-                return [...acc, node];
-            }
-        return acc;
-    }, []);
-};
+            return (node && node.cost > 0) ? [...acc, node] : acc;
+        }, []);
+    };
     const findNeighbors = (node: Node): Node[] => {
 
         const { parent, point: nodePoint } = node;
@@ -151,7 +148,6 @@ export const findPath = (
 
             return getNeighborsByDirection(xDirections, nodePoint, grid);
         }
-
 
         if(normalizedPoint.y !== 0) {
             const xDirections = [

--- a/src/finders/jumpPoint.finder.ts
+++ b/src/finders/jumpPoint.finder.ts
@@ -13,13 +13,20 @@ export const findPath = (
 ): PointInterface[] => {
 
     const openList: OpenList = new OpenList();
-    const startNode: Node = grid.getNode(startPoint);
-    const endNode: Node = grid.getNode(endPoint);
+    const startNode: Node | null = grid.getNode(startPoint);
+    const endNode: Node | null = grid.getNode(endPoint);
+
+    if (startNode === null) {
+        throw ReferenceError('startNode does not exist in the grid');
+    }
+    if (endNode === null) {
+        throw ReferenceError('endNode does not exist in the grid');
+    }
 
     startNode.opened = true;
     openList.push(startNode);
 
-    const jump = (neighbor: Node, node: Node): Node | null => {
+    const jump = (neighbor: Node | null, node: Node): Node | null => {
         if(!neighbor || neighbor.cost === 0)
             return null;
 
@@ -38,16 +45,17 @@ export const findPath = (
             return endNode;
 
         const getNode = (x: number, y: number) => grid.getNode(neighborPoint.copy(x, y));
+        const hasPositiveCost = (cost?: number) => cost ?? -Infinity > 0;
 
         if(correctedPoint.x !== 0 && (
-            (getNode(0, -1)?.cost > 0 && getNode(- correctedPoint.x, -1)?.cost === 0)
-            || (getNode(0, 1)?.cost > 0 && getNode(- correctedPoint.x, 1)?.cost === 0)
+            (hasPositiveCost(getNode(0, -1)?.cost) && getNode(- correctedPoint.x, -1)?.cost === 0)
+            || (hasPositiveCost(getNode(0, 1)?.cost) && getNode(- correctedPoint.x, 1)?.cost === 0)
         )) return neighbor;
 
         else if(correctedPoint.y !== 0) {
             if(
-                (getNode(-1, 0)?.cost > 0 && getNode(- 1, - correctedPoint.y)?.cost === 0)
-                || (getNode(1, 0)?.cost > 0 && getNode(1, - correctedPoint.y)?.cost === 0)
+                (hasPositiveCost(getNode(-1, 0)?.cost) > 0 && getNode(- 1, - correctedPoint.y)?.cost === 0)
+                || (hasPositiveCost(getNode(1, 0)?.cost) && getNode(1, - correctedPoint.y)?.cost === 0)
             ) return neighbor;
 
             if(jump(getNode(1, 0), neighbor) || jump(getNode(-1, 0), neighbor))
@@ -104,6 +112,20 @@ export const findPath = (
         });
     }
 
+    type Direction = [number, number];
+    const getNeighborsByDirection = (
+        directions: Direction[],
+        reference: Point,
+        grid: Grid
+    ) => {
+        return directions.reduce((acc: Node[], direction: [number, number]) => {
+            const node = grid.getNode(reference.copy(...direction));
+            if (node && node.cost > 0) {
+                return [...acc, node];
+            }
+        return acc;
+    }, []);
+};
     const findNeighbors = (node: Node): Node[] => {
 
         const { parent, point: nodePoint } = node;
@@ -120,54 +142,41 @@ export const findPath = (
             getNormalizedNumber(nodePoint.y, parentPoint.y)
         );
 
-        const neighbors: Node[] = [];
-
         if(normalizedPoint.x !== 0) {
-            const topNode = grid.getNode(nodePoint.copy(0, - 1));
-            if (topNode?.cost > 0) neighbors.push(topNode);
+            const xDirections = [
+                [0, -1],
+                [0, 1],
+                [normalizedPoint.x, 0],
+            ] as Direction[];
 
-            const bottomNode = grid.getNode(nodePoint.copy(0, + 1));
-            if (bottomNode?.cost > 0) neighbors.push(bottomNode);
-
-            const normalizedXNode = grid.getNode(nodePoint.copy(normalizedPoint.x, 0));
-            if (normalizedXNode?.cost > 0) neighbors.push(normalizedXNode);
-
-            return neighbors;
+            return getNeighborsByDirection(xDirections, nodePoint, grid);
         }
 
 
         if(normalizedPoint.y !== 0) {
-            const leftNode = grid.getNode(nodePoint.copy(-1, 0));
-            if (leftNode?.cost > 0) neighbors.push(leftNode);
+            const xDirections = [
+                [-1, 0],
+                [1, 0],
+                [0, normalizedPoint.y],
+            ] as Direction[];
 
-            const rightNode = grid.getNode(nodePoint.copy(1, 0));
-            if (rightNode?.cost > 0) neighbors.push(rightNode);
-
-            const normalizedYNode = grid.getNode(nodePoint.copy(0, normalizedPoint.y));
-            if (normalizedYNode?.cost > 0) neighbors.push(normalizedYNode);
-
-            return neighbors;
+            return getNeighborsByDirection(xDirections, nodePoint, grid);
         }
+
+        return []
     }
 
     const getNeighbors = (node: Node): Node[] => {
-        const neighbors: Node[] = [];
         const nodePoint = node.point;
 
-        // ↑
-        const topNode = grid.getNode(nodePoint.copy(0, -1));
-        if (topNode?.cost > 0) neighbors.push(topNode);
-        // →
-        const rightNode = grid.getNode(nodePoint.copy(1, 0));
-        if (rightNode?.cost > 0) neighbors.push(rightNode);
-        // ↓
-        const bottomNode = grid.getNode(nodePoint.copy(0, 1));
-        if (bottomNode?.cost > 0) neighbors.push(bottomNode);
-        // ←
-        const leftNode = grid.getNode(nodePoint.copy(-1, 0));
-        if (leftNode?.cost > 0) neighbors.push(leftNode);
+        const xDirections = [
+            [0, -1],
+            [1, 0],
+            [0, 1],
+            [-1, 0],
+        ] as Direction[];
 
-        return neighbors;
+        return getNeighborsByDirection(xDirections, nodePoint, grid);
     }
 
     while (!openList.empty()) {

--- a/src/objects/grid.ts
+++ b/src/objects/grid.ts
@@ -12,6 +12,9 @@ export class Grid {
     constructor(matrix: number[][]) {
         this._matrix = matrix;
 
+        if(this._matrix[0] === undefined || this._matrix[0][0] === undefined)
+            throw ReferenceError('grid matrix cannot be empty');
+
         this.nodes = this._matrix.map((arrY, y) =>
             arrY.map((cost, x) =>
                 new Node(new Point(x, y), cost)));

--- a/src/objects/grid.ts
+++ b/src/objects/grid.ts
@@ -5,19 +5,12 @@ import {PointInterface} from "./point/point.interface";
 import {FinderEnum} from "../finders/finder.enum";
 
 export class Grid {
-
-    private _width: number;
-    private _height: number;
-
-    private _matrix: number[][];
+    private readonly _matrix: number[][];
 
     public nodes: Node[][];
 
-    constructor(matrix) {
+    constructor(matrix: number[][]) {
         this._matrix = matrix;
-
-        this._height = matrix.length;
-        this._width = matrix[0].length;
 
         this.nodes = this._matrix.map((arrY, y) =>
             arrY.map((cost, x) =>

--- a/src/objects/node.ts
+++ b/src/objects/node.ts
@@ -6,15 +6,15 @@ export class Node {
     public cost: number;
 
     public g: number;
-    public h: number;
     public f: number
+    public h: number = 0;
 
-    public opened: boolean;
-    public closed: boolean;
+    public opened: boolean = false;
+    public closed: boolean = false;
 
-    public parent: Node;
+    public parent?: Node = undefined;
 
-    constructor(point: Point, cost?: number) {
+    constructor(point: Point, cost: number) {
         this.point = point;
         this.cost = cost;
 

--- a/src/objects/node.ts
+++ b/src/objects/node.ts
@@ -6,21 +6,24 @@ export class Node {
     public readonly point: Point;
     public cost: number;
 
-    public distanceFromStart: number;
-    public totalCost: number
-    public heuristicDistance: number;
+    public distanceFromStart: number; //g
+    public heuristicDistance: number; //h
+    public totalCost: number //f
 
-    public opened: boolean = false;
-    public closed: boolean = false;
+    public opened: boolean;
+    public closed: boolean;
 
-    public parent?: Node = undefined;
+    public parent: Node | undefined;
 
     constructor(point: Point, cost: number) {
         this.point = point;
         this.cost = cost;
 
+        this.opened = false;
+        this.closed = false;
+
         this.distanceFromStart = 0;
-        this.totalCost = 0;
         this.heuristicDistance = 0;
+        this.totalCost = 0;
     }
 }

--- a/src/objects/openList.ts
+++ b/src/objects/openList.ts
@@ -2,8 +2,8 @@ import {CompFn, ListNode} from "./openList.types";
 
 export class OpenList<T> {
 
-    private start: ListNode<T>;
-    private end: ListNode<T>;
+    private start: ListNode<T> | null;
+    private end: ListNode<T> | null;
 
     private readonly comparator: CompFn<T>;
 
@@ -14,24 +14,33 @@ export class OpenList<T> {
     }
 
     push(value: T) {
-
         if (this.start === null) {
             // List is empty
-            this.start = {value, prev: null, next: null};
+            this.start = {
+                value,
+                prev: null,
+                next: null
+            };
             this.end = this.start;
             return;
         }
 
         // Find the position to insert into
-        let aux = this.start;
+        let aux: ListNode<T> | null = this.start;
         while (aux !== null && this.comparator(aux.value, value) > 0) {
             aux = aux.next;
         }
 
         if (aux === null) {
             // Inserting at the end
-            const newNode = {value, prev: this.end, next: null};
-            this.end.next = newNode;
+            const newNode = {
+                value,
+                prev:
+                this.end,
+                next: null
+            };
+            if(this.end)
+                this.end.next = newNode;
             this.end = newNode;
             return;
         }
@@ -50,18 +59,18 @@ export class OpenList<T> {
         }
     }
 
-    pop(): T {
-        if (this.empty()) {
-            throw new Error("Popping from an empty list.");
-        }
+    pop(): T | null {
+        if (this.empty())
+            throw ReferenceError("popping from an empty list");
+
         const popped = this.end;
-        this.end = popped.prev;
+        this.end = popped?.prev as (ListNode<T> | null);
         if (this.end === null) {
             this.start = null;
         } else {
             this.end.next = null;
         }
-        return popped.value;
+        return popped?.value || null;
     }
 
     empty(): boolean {

--- a/src/objects/openList.types.ts
+++ b/src/objects/openList.types.ts
@@ -3,6 +3,6 @@ export type CompFn<T> = (a: T, b: T) => number;
 
 export type ListNode<T> = {
     value: T,
-    prev: ListNode<T>,
-    next: ListNode<T>
+    prev: ListNode<T> | null,
+    next: ListNode<T> | null
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,15 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2017",
-    "sourceMap": false
+    "sourceMap": false,
+    // stricter type-checking for stronger correctness. Recommended by TS
+    "strict": true,
+    // significant perf increase by skipping checking .d.ts files, particularly those in node_modules. Recommended by TS
+    "skipLibCheck": true,
+    // error out if import and file system have a casing mismatch. Recommended by TS
+    "forceConsistentCasingInFileNames": true,
+    // output .d.ts declaration files for consumers
+    "declaration": true
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
This PR adds the next changes:

- Apply TS strict mode (stronger type when checking nodes in the algorithm)
- Exports both typings and normal js compile. To make it compatible with non-TypeScript implementations
- Adds test cases and makes it Data Driven
- Simplifies the `findNeightbors` to be more reusable