### PR TITLE
Fix jump bug

### DIFF
--- a/__tests__/pathFinding.test.ts
+++ b/__tests__/pathFinding.test.ts
@@ -68,6 +68,30 @@ describe('test path finding', () => {
                 { x: 4, y: 4 },
             ],
         },
+        {
+            grid: grid_A,
+            startPoint: { x: 4, y: 3 },
+            endPoint: { x: 0, y: 1 },
+            maxJumpCost: 5,
+            path: [
+                { x: 4, y: 3 },
+                { x: 4, y: 4 },
+                { x: 0, y: 4 },
+                { x: 0, y: 1 },
+            ],
+        },
+        {
+            grid: grid_A,
+            startPoint: { x: 0, y: 1 },
+            endPoint: { x: 4, y: 3 },
+            maxJumpCost: 5,
+            path: [
+                { x: 0, y: 1 },
+                { x: 0, y: 4 },
+                { x: 4, y: 4 },
+                { x: 4, y: 3 },
+            ],
+        },
     ] as {
         grid: Grid;
         startPoint: PointInterface;
@@ -83,7 +107,7 @@ describe('test path finding', () => {
         path: expectedPath,
         grid
     }) => {
-        it(`validates pathfinding for jumpCost  ${maxJumpCost}`, () => {
+        it(`validates pathfinding from ${Object.values(startPoint)} to ${Object.values(endPoint)} with jumpCost  ${maxJumpCost}`, () => {
             const path = grid.findPath(startPoint, endPoint, maxJumpCost);
             expect(path).toEqual(expectedPath);
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pathfinding.ts",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/finders/jumpPoint.finder.ts
+++ b/src/finders/jumpPoint.finder.ts
@@ -41,9 +41,6 @@ export const findPath = (
             neighborPoint.y - nodePoint.y,
         );
 
-        if(correctedPoint.equal(endNode.point))
-            return endNode;
-
         const getNode = (x: number, y: number) => grid.getNode(neighborPoint.copy(x, y));
         const hasPositiveCost = (cost?: number) => cost ?? -Infinity > 0;
 


### PR DESCRIPTION
```ts
if(correctedPoint.equal(endNode.point))	
            return endNode;
```

That comparison is unneeded and incorrect as correctedPoint does not correspond to a real point, but to a relative vector